### PR TITLE
Add support for ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Point your browser to http://yourdockerhost:7990
 1. Create and enter license information
 1. Fill out the rest of the installation procedure.
 
+# SSH Keys
+
+If you need to use SSH Keys to authenticate Bitbucket to other services (eg, replicating to Github), put the entire contents of what you want to have in the .ssh directory in a directory called 'ssh' on your persistant volume.
+
+When the container is started, the contents of that directory will be copied to /home/bitbucket/.ssh, and the permissions will be set to 700.
+
 # Proxy Configuration
 
 You can specify your proxy host and proxy port with the environment variables BITBUCKET_PROXY_NAME and BITBUCKET_PROXY_PORT. The value will be set inside the Atlassian server.xml at startup!

--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -28,6 +28,13 @@ fi
 
 processBitbucketProxySettings
 
+# If there is a 'ssh' directory, copy it to /home/bitbucket/.ssh
+if [ -d /var/atlassian/bitbucket/ssh ]; then
+  mkdir -p /home/bitbucket/.ssh
+  cp -R /var/atlassian/bitbucket/ssh/* /home/bitbucket/.ssh
+  chmod -R 700 /home/bitbucket/.ssh
+fi
+
 if [ "$1" = 'bitbucket' ] || [ "${1:0:1}" = '-' ]; then
   umask 0027
   exec ${BITBUCKET_INSTALL}/bin/catalina.sh run -fg


### PR DESCRIPTION
It's common to want to use SSH keys for your Bitbucket server to
communicate and authenticate with other servers. This allows you
to create a 'ssh' directory in your persistant volume, which will
then be copied to /home/bitbucket/.ssh on the startup of the
container.