### PR TITLE
Dedicated sed command for variables beginning with /

### DIFF
--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -18,7 +18,11 @@ function updateBitbucketProperties() {
   grep -q "${propertyname}=" ${propertyfile}
   if [ $? -eq 0 ]; then
     set -e
-    sed -i "s/\(${propertyname/./\\.}=\).*\$/\1\\${propertyvalue}/" ${propertyfile}
+    if [[ $propertyvalue == /* ]]; then
+      sed -i "s/\(${propertyname/./\\.}=\).*\$/\1\\${propertyvalue}/" ${propertyfile}
+    else
+      sed -i "s/\(${propertyname/./\\.}=\).*\$/\1${propertyvalue}/" ${propertyfile}
+    fi
   else
     set -e
     echo "${propertyname}=${propertyvalue}" >> ${propertyfile}


### PR DESCRIPTION
Two \\ will also escape numbers. I.e. server.proxy-port=80 will be set
to server.proxy-port=0. I didn’t realize this during my fist change.