### PR TITLE
Bitbucket upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:openjre.8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG BITBUCKET_VERSION=5.3.1
+ARG BITBUCKET_VERSION=5.4.0
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000
@@ -12,7 +12,7 @@ ENV BITBUCKET_HOME=/var/atlassian/bitbucket \
     BITBUCKET_PROXY_PORT= \
     BITBUCKET_PROXY_SCHEME=
 
-RUN export MYSQL_DRIVER_VERSION=5.1.38 && \
+RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
     export CONTAINER_USER=bitbucket &&  \
     export CONTAINER_GROUP=bitbucket &&  \
     addgroup -g $CONTAINER_GID $CONTAINER_GROUP &&  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
       openssh \
       git \
       perl \
-      wget &&  \
+      wget  \
+      ttf-dejavu && \
     # Install xmlstarlet
     export XMLSTARLET_VERSION=1.6.1-r1              &&  \
     wget --directory-prefix=/tmp https://github.com/menski/alpine-pkg-xmlstarlet/releases/download/${XMLSTARLET_VERSION}/xmlstarlet-${XMLSTARLET_VERSION}.apk && \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Bitbucket | 5.3.1 | 5.3.1, latest | [Dockerfile](https://github.com/blacklabelops/bitbucket/blob/master/Dockerfile) |
+| Bitbucket | 5.4.0 | 5.4.0, latest | [Dockerfile](https://github.com/blacklabelops/bitbucket/blob/master/Dockerfile) |
 
 ## Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export BITBUCKET_VERSION=5.3.1
+export BITBUCKET_VERSION=5.4.0


### PR DESCRIPTION
* Upgrade to Bitbucket 5.4.0
* Add ttf-dejavu for Captcha support per: https://confluence.atlassian.com/bitbucketserverkb/captcha-image-doesn-t-render-779171210.html