### PR TITLE
Add git-daemon package to enable git http-access.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
       git \
       perl \
       wget  \
-      ttf-dejavu && \
+      ttf-dejavu \
+      git-daemon && \
     # Install xmlstarlet
     export XMLSTARLET_VERSION=1.6.1-r1              &&  \
     wget --directory-prefix=/tmp https://github.com/menski/alpine-pkg-xmlstarlet/releases/download/${XMLSTARLET_VERSION}/xmlstarlet-${XMLSTARLET_VERSION}.apk && \


### PR DESCRIPTION
In alpine:3.7 the `git`-package no longer contains `/usr/libexec/git-core/git-http-backend` but rather packaged this tool into `git-daemon`-package.

See:

https://pkgs.alpinelinux.org/contents?file=git-http-backend&branch=v3.6&repo=main&arch=x86_64 and
https://pkgs.alpinelinux.org/contents?file=git-http-backend&branch=v3.7&repo=main&arch=x86_64

This bug was introduced by https://github.com/blacklabelops/java/commit/ab4b0d07b0cf3fd654bb937b1694ad891a17b801