### PR TITLE
Bitbucket 5.7.0 -> 5.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:openjre.8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG BITBUCKET_VERSION=5.7.0
+ARG BITBUCKET_VERSION=5.7.1
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export BITBUCKET_VERSION=5.7.0
+export BITBUCKET_VERSION=5.7.1


### PR DESCRIPTION
Update to Bitbucket 5.7.1

Release notes: https://confluence.atlassian.com/bitbucketserver/bitbucket-server-5-7-release-notes-939918798.html