### PR TITLE
Bitbucket 5.8.0 -> 5.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:openjre.8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG BITBUCKET_VERSION=5.8.0
+ARG BITBUCKET_VERSION=5.8.1
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Bitbucket | 5.8.0 | 5.8.0, latest | [Dockerfile](https://github.com/blacklabelops/bitbucket/blob/master/Dockerfile) |
+| Bitbucket | 5.8.1 | 5.8.1, latest | [Dockerfile](https://github.com/blacklabelops/bitbucket/blob/master/Dockerfile) |
 
 ## Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export BITBUCKET_VERSION=5.8.0
+export BITBUCKET_VERSION=5.8.1


### PR DESCRIPTION
Bitbucket 5.8.1 release notes: https://confluence.atlassian.com/bitbucketserver/bitbucket-server-5-8-release-notes-943973059.html