### PR TITLE
Update to 7.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG BITBUCKET_VERSION=6.8.2
+ARG BITBUCKET_VERSION=7.3.1
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN export MYSQL_DRIVER_VERSION=5.1.48 && \
 
 RUN mkdir -p ${BITBUCKET_BACKUP_CLIENT_HOME} && \
     wget -O /tmp/bitbucket-backup-distribution.zip \
+      --local-encoding=utf-8 \
       https://marketplace.atlassian.com/download/plugins/com.atlassian.stash.backup.client/version/${BITBUCKET_BACKUP_CLIENT_VERSION} && \
     unzip -d ${BITBUCKET_BACKUP_CLIENT_HOME} /tmp/bitbucket-backup-distribution.zip && \
     mv /opt/backupclient/$(ls /opt/backupclient/) /opt/backupclient/bitbucket-backup-client && \

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 You may also like:
 
-* [blacklabelops/jira](https://github.com/blacklabelops/jira): The #1 software development tool used by agile teams
-* [blacklabelops/confluence](https://github.com/blacklabelops/confluence): Create, organize, and discuss work with your team
-* [blacklabelops/bitbucket](https://github.com/blacklabelops/bitbucket): Code, Manage, Collaborate
-* [blacklabelops/crowd](https://github.com/blacklabelops/crowd): Identity management for web apps
+* [teamatldocker/jira](https://github.com/teamatldocker/jira): The #1 software development tool used by agile teams
+* [teamatldocker/confluence](https://github.com/teamatldocker/confluence): Create, organize, and discuss work with your team
+* [teamatldocker/bitbucket](https://github.com/teamatldocker/bitbucket): Code, Manage, Collaborate
+* [teamatldocker/crowd](https://github.com/teamatldocker/crowd): Identity management for web apps
 
 # Make It Short
 
@@ -24,7 +24,7 @@ Docker-CLI:
 Just type and follow the manual installation procedure in your browser:
 
 ~~~~
-$ docker run -d -p 7990:7990 --name bitbucket blacklabelops/bitbucket
+$ docker run -d -p 7990:7990 --name bitbucket teamatldocker/bitbucket
 ~~~~
 
 > Point your browser to http://yourdockerhost:7990
@@ -45,7 +45,7 @@ $ docker run --name postgres_bitbucket -d \
     -e 'POSTGRES_USER=bitbucketdb' \
     -e 'POSTGRES_PASSWORD=jellyfish' \
     -e 'POSTGRES_ENCODING=UTF8' \
-    blacklabelops/postgres
+    postgres:9.5-alpine
 ~~~~
 
 Secondly, start Bitbucket:
@@ -53,7 +53,7 @@ Secondly, start Bitbucket:
 ~~~~
 $ docker run -d --name bitbucket \
 	  --link postgres_bitbucket:postgres_bitbucket \
-	  -p 7990:7990 blacklabelops/bitbucket
+	  -p 7990:7990 teamatldocker/bitbucket
 ~~~~
 
 >  Starts Crowd and links it to the postgresql instances. JDBC URL: jdbc:postgresql://postgres_bitbucket/bitbucketdb
@@ -83,7 +83,7 @@ $ docker run -d --name bitbucket \
     -v your-local-folder-or-volume:/var/atlassian/bitbucket \
     -e "BITBUCKET_EMBEDDED_SEARCH=true" \
     -p 7990:7990 \
-    blacklabelops/bitbucket /opt/bitbucket/bin/start-bitbucket.sh -fg
+    teamatldocker/bitbucket /opt/bitbucket/bin/start-bitbucket.sh -fg
 ~~~~
 
 > A separate java process for Elasticsearch will be started.
@@ -108,7 +108,7 @@ First start the polling container:
 $ docker run -d --name bitbucket \
     -e "DOCKER_WAIT_HOST=your_postgres_host" \
     -e "DOCKER_WAIT_PORT=5432" \
-    -p 80:8090 blacklabelops/bitbucket
+    -p 80:8090 teamatldocker/bitbucket
 ~~~~
 
 > Waits at most 60 seconds for the database.
@@ -125,7 +125,7 @@ $ docker run --name postgres -d \
     -e 'POSTGRES_ENCODING=UNICODE' \
     -e 'POSTGRES_COLLATE=C' \
     -e 'POSTGRES_COLLATE_TYPE=C' \
-    blacklabelops/postgres
+    postgres:9.5-alpine
 ~~~~
 
 > Bitbucket will start after postgres is available!
@@ -144,7 +144,7 @@ $ docker run -d --name bitbucket \
     -e "BITBUCKET_PROXY_NAME=myhost.example.com" \
     -e "BITBUCKET_PROXY_PORT=443" \
     -e "BITBUCKET_PROXY_SCHEME=https" \
-    blacklabelops/bitbucket
+    teamatldocker/bitbucket
 ~~~~
 
 > ssh keys will be copied and are available at runtime.
@@ -211,7 +211,7 @@ $ docker run --rm --name bitbucket_backup \
     -e "BITBUCKET_BASEURL=http://yourbitbucketserverurl:yourport" \
     -e "BITBUCKET_USER=youradmin" \
     -e "BITBUCKET_PASSWORD=yourpassword" \
-    blacklabelops/bitbucket \
+    teamatldocker/bitbucket \
     java -jar /opt/backupclient/bitbucket-backup-client/bitbucket-backup-client.jar
 ~~~~
 
@@ -228,7 +228,7 @@ $ docker run -d \
     -e "JVM_MINIMUM_MEMORY=2g" \
     -e "JVM_MAXIMUM_MEMORY=3g" \
     -p 7990:7990 \
-    blacklabelops/bitbucket
+    teamatldocker/bitbucket
 ~~~~
 
 This will start Bitbucket with `-Xms=2g -Xmx=3g`.
@@ -254,7 +254,7 @@ $ docker run -d --name bitbucket \
     -e "BITBUCKET_PROXY_NAME=myhost.example.com" \
     -e "BITBUCKET_PROXY_PORT=443" \
     -e "BITBUCKET_PROXY_SCHEME=https" \
-    blacklabelops/bitbucket
+    teamatldocker/bitbucket
 ~~~~
 
 > Will set the values inside the bitbucket.properties in /var/atlassian/bitbucket/bitbucket.properties
@@ -271,7 +271,7 @@ $ docker run -d --name bitbucket \
     -e "BITBUCKET_PROXY_NAME=myhost.example.com" \
     -e "BITBUCKET_PROXY_PORT=80" \
     -e "BITBUCKET_PROXY_SCHEME=http" \
-    blacklabelops/bitbucket
+    teamatldocker/bitbucket
 ~~~~
 
 > Example with dockertools
@@ -305,7 +305,7 @@ $ docker run -d --name bitbucket \
     -e "BITBUCKET_PROXY_NAME=192.168.99.100" \
     -e "BITBUCKET_PROXY_PORT=80" \
     -e "BITBUCKET_PROXY_SCHEME=http" \
-    blacklabelops/bitbucket
+    teamatldocker/bitbucket
 ~~~~
 
 > Example with dockertools
@@ -361,7 +361,7 @@ Example:
 ~~~~
 $ docker run -d -p 7990:7990 -v your-local-folder-or-volume:/var/atlassian/bitbucket \
     -e "BITBUCKET_CROWD_SSO=true" \
-    --name bitbucket blacklabelops/bitbucket
+    --name bitbucket teamatldocker/bitbucket
 ~~~~
 
  > SSO will be activated, you will need Crowd in order to authenticate.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Bitbucket | 6.8.2 | 6.8.2, latest | [Dockerfile](https://github.com/blacklabelops/bitbucket/blob/master/Dockerfile) |
+| Bitbucket | 7.3.1 | 7.3.1, latest | [Dockerfile](https://github.com/teamatldocker/bitbucket/blob/master/Dockerfile) |
 
 ## Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,7 +3,7 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export BITBUCKET_VERSION=6.8.2
+export BITBUCKET_VERSION=7.3.1
 
 docker build -t teamatldocker/bitbucket .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   bitbucket:
-    image: blacklabelops/bitbucket
+    image: teamatldocker/bitbucket
     depends_on:
       - postgres_bitbucket
     networks:
@@ -19,11 +19,11 @@ services:
       - 'DOCKER_WAIT_HOST=postgres_bitbucket'
       - 'DOCKER_WAIT_PORT=5432'
     labels:
-      com.blacklabelops.description: "Atlassian Bitbucket"
-      com.blacklabelops.service: "bitbucket"
+      com.teamatldocker.description: "Atlassian Bitbucket"
+      com.teamatldocker.service: "bitbucket"
 
   postgres_bitbucket:
-    image: blacklabelops/postgres
+    image: postgres:9.5-alpine
     networks:
       - bitbucketnet
     volumes:
@@ -35,8 +35,8 @@ services:
       - 'POSTGRES_DB=bitbucketdb'
       - 'POSTGRES_ENCODING=UTF8'
     labels:
-      com.blacklabelops.description: "PostgreSQL Database Server"
-      com.blacklabelops.service: "postgresql"
+      com.teamatldocker.description: "PostgreSQL Database Server"
+      com.teamatldocker.service: "postgresql"
 
 volumes:
   bitbucketdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - 'BITBUCKET_DELAYED_START='
       - 'DOCKER_WAIT_HOST=postgres_bitbucket'
       - 'DOCKER_WAIT_PORT=5432'
+      - 'BITBUCKET_EMBEDDED_SEARCH=true'
     labels:
       com.teamatldocker.description: "Atlassian Bitbucket"
       com.teamatldocker.service: "bitbucket"


### PR DESCRIPTION
Pull in the latest Bitbucket, version 7.3.1.

- Update the version number in a handful or fewer places
- Update mentions of `blacklabelops/bitbucket` to `teamatldocker/bitbucket`
- Move from `blacklabelops/postgres` to `postgres:9.5-alpine` (as used already by `teamatldocker/jira`)
- Leave mentions of `blacklabelops/nginx` (punting)
- Add build method to docker-compose
- Enable Elasticsearch by default in docker-compose (should probably make this default everywhere)
- Fix `wget` issue when downloading backup client by enforcing local UTF-8 encoding

I just did a test run to upgrade an old 5.x instance to 7.3.1, and so far so good.